### PR TITLE
Feat: Thumbnail image

### DIFF
--- a/wafflemarket/article/models.py
+++ b/wafflemarket/article/models.py
@@ -60,4 +60,9 @@ class ProductImage(models.Model):
         Article, related_name="product_images", null=False, on_delete=models.CASCADE
     )
     product_image = models.ImageField(upload_to=upload_product_image)
-    product_thumbnail = ProcessedImageField(null=True, upload_to=upload_product_image,processors=[ResizeToFit(height=120)], format='JPEG')
+    product_thumbnail = ProcessedImageField(
+        null=True,
+        upload_to=upload_product_image,
+        processors=[ResizeToFit(height=120)],
+        format="JPEG",
+    )

--- a/wafflemarket/article/models.py
+++ b/wafflemarket/article/models.py
@@ -1,3 +1,6 @@
+from imagekit.models import ProcessedImageField
+from imagekit.processors import ResizeToFit
+
 from django.db import models
 
 from user.models import User
@@ -17,7 +20,6 @@ class Article(models.Model):
     )
     title = models.CharField(max_length=20)
     content = models.CharField(max_length=255)
-    product_image = models.ImageField(blank=True, upload_to=upload_product_image)
     category = models.CharField(max_length=20)
     price = models.PositiveBigIntegerField(null=True)
     created_at = models.DateTimeField(auto_now_add=True)
@@ -58,3 +60,4 @@ class ProductImage(models.Model):
         Article, related_name="product_images", null=False, on_delete=models.CASCADE
     )
     product_image = models.ImageField(upload_to=upload_product_image)
+    product_thumbnail = ProcessedImageField(null=True, upload_to=upload_product_image,processors=[ResizeToFit(height=120)], format='JPEG')

--- a/wafflemarket/article/serializers.py
+++ b/wafflemarket/article/serializers.py
@@ -149,17 +149,17 @@ class CommentSerializer(serializers.ModelSerializer):
 
 
 class ProductImageSerializer(serializers.ModelSerializer):
-    original_url = serializers.SerializerMethodField(read_only=True)
+    image_url = serializers.SerializerMethodField(read_only=True)
     thumbnail_url = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
         model = ProductImage
         fields = (
-            "original_url",
+            "image_url",
             "thumbnail_url",
         )
 
-    def get_original_url(self, object):
+    def get_image_url(self, object):
         url = object.product_image.url
         if url.find("?") == -1:
             return url

--- a/wafflemarket/article/serializers.py
+++ b/wafflemarket/article/serializers.py
@@ -149,14 +149,24 @@ class CommentSerializer(serializers.ModelSerializer):
 
 
 class ProductImageSerializer(serializers.ModelSerializer):
-    url = serializers.SerializerMethodField(read_only=True)
+    original_url = serializers.SerializerMethodField(read_only=True)
+    thumbnail_url = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
         model = ProductImage
-        fields = ("url",)
+        fields = (
+            "original_url",
+            "thumbnail_url",
+        )
 
-    def get_url(self, object):
+    def get_original_url(self, object):
         url = object.product_image.url
+        if url.find("?") == -1:
+            return url
+        return url[: url.find("?")]
+
+    def get_thumbnail_url(self, object):
+        url = object.product_thumbnail.url
         if url.find("?") == -1:
             return url
         return url[: url.find("?")]

--- a/wafflemarket/article/views.py
+++ b/wafflemarket/article/views.py
@@ -2,8 +2,8 @@ from rest_framework import status, viewsets, permissions
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from django.core.files.base import ContentFile
 
+from django.core.files.base import ContentFile
 from django.core.paginator import Paginator
 from django.utils import timezone
 
@@ -38,10 +38,11 @@ class ArticleViewSet(viewsets.GenericViewSet):
         for i in range(1, image_count + 1):
             field_name = "image_" + str(i)
             image = request.FILES.get(field_name)
-            new_image = ContentFile(image.read())
-            new_image.name = image.name
-
-            ProductImage.objects.create(article=article, product_image=image, product_thumbnail=new_image)
+            thumbnail = ContentFile(image.read())
+            thumbnail.name = image.name
+            ProductImage.objects.create(
+                article=article, product_image=image, product_thumbnail=thumbnail
+            )
         return Response(
             self.get_serializer(article).data, status=status.HTTP_201_CREATED
         )

--- a/wafflemarket/article/views.py
+++ b/wafflemarket/article/views.py
@@ -2,6 +2,7 @@ from rest_framework import status, viewsets, permissions
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from django.core.files.base import ContentFile
 
 from django.core.paginator import Paginator
 from django.utils import timezone
@@ -27,7 +28,7 @@ class ArticleViewSet(viewsets.GenericViewSet):
         serializer.is_valid(raise_exception=True)
         image_count = int(serializer.data["image_count"])
         for i in range(1, image_count + 1):
-            field_name = "product_image_" + str(i)
+            field_name = "image_" + str(i)
             if request.FILES.get(field_name) is None:
                 return Response(
                     data="업로드 형식이 올바르지 않습니다.", status=status.HTTP_400_BAD_REQUEST
@@ -35,9 +36,12 @@ class ArticleViewSet(viewsets.GenericViewSet):
 
         article = serializer.create_article(serializer.validated_data, request.user)
         for i in range(1, image_count + 1):
-            field_name = "product_image_" + str(i)
-            product_image = request.FILES.get(field_name)
-            ProductImage.objects.create(article=article, product_image=product_image)
+            field_name = "image_" + str(i)
+            image = request.FILES.get(field_name)
+            new_image = ContentFile(image.read())
+            new_image.name = image.name
+
+            ProductImage.objects.create(article=article, product_image=image, product_thumbnail=new_image)
         return Response(
             self.get_serializer(article).data, status=status.HTTP_201_CREATED
         )

--- a/wafflemarket/requirements.txt
+++ b/wafflemarket/requirements.txt
@@ -14,3 +14,4 @@ django_storages # for file storage
 django-google-oauth # for google login
 pillow # for imagefield usage
 boto3 # for S3 connection
+django-imagekit # for generating thumbnail

--- a/wafflemarket/wafflemarket/settings.py
+++ b/wafflemarket/wafflemarket/settings.py
@@ -48,7 +48,6 @@ DJANGO_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django.contrib.sites",
-    "django_filters",
 ]
 
 PROJECT_APPS = [
@@ -64,6 +63,8 @@ THIRD_PARTY_APPS = [
     "rest_framework.authtoken",
     "six",
     "storages",
+    "django_filters",
+    "imagekit",
 ]
 
 INSTALLED_APPS = DJANGO_APPS + PROJECT_APPS + THIRD_PARTY_APPS


### PR DESCRIPTION
이제 image_url에서 원본 사진 url을, thumbnail_url에서 썸네일 url을 전송합니다. 
프론트 분들은 request는 이전과 같은 형식으로 보내면 되고, 나중에 테스트해보시고 화질 조정이 필요하면 말해주세요.
참고로 썸네일 이미지도 원본 사진과 같은 디렉토리에 저장되는데, 이것도 수정 원하시면 코멘트 달아주세요.