### PR TITLE
Fix: Add user delete

### DIFF
--- a/wafflemarket/article/views.py
+++ b/wafflemarket/article/views.py
@@ -7,6 +7,7 @@ from rest_framework.views import APIView
 
 from django.core.files.base import ContentFile
 from django.core.paginator import Paginator
+from django.db.models import Q
 from django.utils import timezone
 
 from user.models import User
@@ -196,7 +197,7 @@ class ArticleViewSet(viewsets.GenericViewSet):
         neighborhood = [user.location.id]
         for location_neighborhood in user.location.neighborhoods.all():
             neighborhood.append(location_neighborhood.neighborhood.id)
-        articles = self.queryset.filter(location__id__in=neighborhood)
+        articles = self.queryset.filter(Q(location__id__in=neighborhood)&Q(seller__is_active=True))
 
         if not keyword:
             # check categories to filter article
@@ -245,7 +246,7 @@ class ArticleViewSet(viewsets.GenericViewSet):
         )
 
     def retrieve(self, request, pk=None):
-        if Article.objects.filter(id=pk).exists():
+        if Article.objects.filter(Q(id=pk)&Q(seller__is_active=True)).exists():
             article = Article.objects.get(id=pk)
         else:
             return Response({"해당하는 게시글을 찾을 수 없습니다."}, status=status.HTTP_404_NOT_FOUND)

--- a/wafflemarket/user/views.py
+++ b/wafflemarket/user/views.py
@@ -123,11 +123,10 @@ class UserLeaveView(APIView):
     permission_classes = (permissions.IsAuthenticated,)
 
     def delete(self, request):
-        # 우선 임시탈퇴를 영구탈퇴로 변경하여 구현함
-        """request.user.is_active = False
+        # temporarily unactivated
+        request.user.is_active = False
         request.user.save()
-        logout(request)"""
-        request.user.delete()
+        logout(request)
         return Response(data={"leaved": True}, status=status.HTTP_200_OK)
 
 


### PR DESCRIPTION
serializer를 바꾸는 쪽으로 하려다가 한도 끝도 없을 것 같아서 그냥 영구탈퇴에서 임시탈퇴로 변경했습니다.
`is_active=False`인 유저의 article은 메인 화면에 뜨지 않고 접근은 불가능합니다.
상대방이 프로필을 열람할때 유저 이름이 변경되어 나타납니다.(다른건 다 잘 뜹니다. 판매 상품 보기도 제대로 뜨는데 세부 접근만 안됩니다.)
로그인시 다시 `is_active=True`가 됩니다.