### PR TITLE
Fix: Change to solve errors in user like, history api

### DIFF
--- a/wafflemarket/article/serializers.py
+++ b/wafflemarket/article/serializers.py
@@ -5,6 +5,7 @@ from rest_framework import serializers
 from user.serializers import UserSimpleSerializer
 from location.serializers import LocationSerializer
 from article.models import Article, Comment, ProductImage
+from review.models import Review
 
 
 class ArticleCreateSerializer(serializers.Serializer):
@@ -79,6 +80,7 @@ class ArticleSerializer(serializers.ModelSerializer):
     sold_at = serializers.SerializerMethodField(read_only=True)
     
     user_liked = serializers.SerializerMethodField(read_only=True)
+    review_exists =  serializers.SerializerMethodField(read_only=True)
 
     class Meta:
         model = Article
@@ -98,6 +100,7 @@ class ArticleSerializer(serializers.ModelSerializer):
             "like",
             "user_liked",
             "hit",
+            "review_exists"
         )
 
     def get_seller(self, article):
@@ -136,6 +139,16 @@ class ArticleSerializer(serializers.ModelSerializer):
     def get_user_liked(self, article):
         user = self.context["user"]
         return user in article.liked_users.all()
+    
+    def get_review_exists(self, article):
+        user = self.context["user"]
+        seller_review_exists = Review.objects.filter(review_type="seller", article=article, reviewer=user).exists()
+        buyer_review_exists = Review.objects.filter(review_type="buyer", article=article, reviewer=user).exists()
+        return {
+            "seller" : seller_review_exists,
+            "buyer" : buyer_review_exists
+        }
+        
         
 
 

--- a/wafflemarket/review/views.py
+++ b/wafflemarket/review/views.py
@@ -103,7 +103,7 @@ class ReviewArticleViewSet(viewsets.GenericViewSet):
         else:
             return Response({"존재하지 않는 게시글입니다."}, status=status.HTTP_404_NOT_FOUND)
         
-        if article.seller != request.user or article.sold_at is None:
+        if article.seller != request.user or article.buyer is None:
             return Response({"리뷰를 작성할 권한이 없습니다."}, status=status.HTTP_403_FORBIDDEN)
         
         if Review.objects.filter(article=article, reviewer=request.user):

--- a/wafflemarket/user/urls.py
+++ b/wafflemarket/user/urls.py
@@ -31,7 +31,7 @@ urlpatterns = [
     path("leave/", UserLeaveView.as_view(), name="leave"),  # /api/v1/leave/
     path(
         "user/category/", UserCategoryView.as_view(), name="category"
-    ),  # /api/v1/user/interest/
+    ),  # /api/v1/user/category/
     path(
         "user/history/<int:pk>/", UserHistoryView.as_view(), name="history"
     ), # /api/v1/user/history/{id} (구매내역 : 1, 판매내역 : 2)

--- a/wafflemarket/user/views.py
+++ b/wafflemarket/user/views.py
@@ -237,23 +237,18 @@ class UserHistoryView(APIView):
     def get(self, request, pk=None):
         if pk==1: #구매내역 : 1
             article = Article.objects.filter(buyer=request.user).order_by('-created_at')
-            review_exists = Review.objects.filter(review_type="seller", article=article, reviewer=request.user).exists()
             
         elif pk==2: #판매내역 : 2
             sold = request.query_params.get('sold')
             if sold=='true':
                 article = Article.objects.filter(seller=request.user, sold_at__isnull=False).order_by('-created_at')
-                review_exists = Review.objects.filter(review_type="seller", article=article, reviewer=request.user).exists()
             elif sold=='false':
                 article = Article.objects.filter(seller=request.user, sold_at__isnull=True).order_by('-created_at')
-                review_exists = False
             else:
                 article = Article.objects.filter(seller=request.user).order_by('-created_at')
-                review_exists = Review.objects.filter(review_type="seller", article=article, reviewer=request.user).exists()
         
         else:
             return Response({"올바른 요청을 보내세요."}, status=status.HTTP_400_BAD_REQUEST)
                 
         data = ArticleSerializer(article, many=True, context = {"user" : request.user}).data
-        data["review_exists"] = review_exists
         return Response(data, status=status.HTTP_200_OK)

--- a/wafflemarket/user/views.py
+++ b/wafflemarket/user/views.py
@@ -228,7 +228,7 @@ class UserLikedView(APIView):
         user = request.user
         article = user.liked_articles.all()
         return Response(
-            ArticleSerializer(article, many=True).data, status=status.HTTP_200_OK
+            ArticleSerializer(article, many=True, context = {"user" : request.user}).data, status=status.HTTP_200_OK
         )
          
 class UserHistoryView(APIView):
@@ -254,6 +254,6 @@ class UserHistoryView(APIView):
         else:
             return Response({"올바른 요청을 보내세요."}, status=status.HTTP_400_BAD_REQUEST)
                 
-        data = ArticleSerializer(article, many=True).data
+        data = ArticleSerializer(article, many=True, context = {"user" : request.user}).data
         data["review_exists"] = review_exists
         return Response(data, status=status.HTTP_200_OK)


### PR DESCRIPTION
1. liked, history api의 경우 ArticleSerializer의 context에 request.user를 포함하지 않아 발생하는 KeyError를 해결했습니다

2. history api의 에러 원인을 제거하였으며, ArticleSerializer에 review_exists 필드를 추가했습니다. 
"review_exists" : {"seller" : True, "buyer" : False}와 같은 형태로 나타납니다.

3. 구매자 선택을 하지 않은 상태로 review를 작성하려고 할 때 권한이 부여되지 않도록 수정했습니다.

